### PR TITLE
feat: support async plugins in rspack

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -13,6 +13,14 @@ export function getWebpackPlugin<UserOptions>(
         compiler.hooks.beforeRun.tapPromise(name, async () => {
           executePlugins(compiler, framework, await plugins)
         })
+
+        /**
+         * `beforeRun` hook is only triggered when calling compiler.run() (rspack build), and will not be executed in watch mode (rspack dev). Use `watchRun` hook in watch mode.
+         */
+        if (framework === 'rspack')
+          compiler.hooks.watchRun.tapPromise(name, async () => {
+            executePlugins(compiler, framework, await plugins)
+          })
       } else {
         executePlugins(compiler, framework, plugins)
       }


### PR DESCRIPTION
### Description

In [Rspack doc](https://rspack.rs/api/plugin-api/compiler-hooks#beforerun), `beforeRun` hook is only triggered when rspack build but not in in watch mode (rspack dev).So call `watchRun` in watch mode as well.

### Linked Issues
https://github.com/vue-macros/vue-macros/issues/984

